### PR TITLE
feat: automatically use a namespace of already installed app when updating/repairing

### DIFF
--- a/legendary/cli.py
+++ b/legendary/cli.py
@@ -854,6 +854,8 @@ class LegendaryCLI:
         args.app_name = self._resolve_aliases(args.app_name)
         if self.core.is_installed(args.app_name):
             igame = self.core.get_installed_game(args.app_name)
+            if not args.namespace:
+                args.namespace = igame.namespace
             args.platform = igame.platform
             if igame.needs_verification and not args.repair_mode:
                 logger.info('Game needs to be verified before updating, switching to repair mode...')


### PR DESCRIPTION
this should let us call an update and avoid having to always specify a namespace in that case